### PR TITLE
Add clang_only_deps to mixed_language_library 

### DIFF
--- a/mixed_language/mixed_language_library.bzl
+++ b/mixed_language/mixed_language_library.bzl
@@ -65,7 +65,7 @@ def mixed_language_library(
     """Creates a mixed language library from a Clang and Swift library target \
     pair.
 
-    Note: In the future `swift_library` will support mixed-langauge libraries.
+    Note: In the future `swift_library` will support mixed-language libraries.
     Once that is the case, this macro will be deprecated.
 
     Args:

--- a/mixed_language/mixed_language_library.bzl
+++ b/mixed_language/mixed_language_library.bzl
@@ -38,6 +38,7 @@ def mixed_language_library(
         alwayslink = False,
         clang_copts = [],
         clang_defines = [],
+        clang_only_deps = [],
         clang_srcs,
         data = [],
         enable_modules = False,
@@ -85,6 +86,8 @@ def mixed_language_library(
             only to the compiler for this target (as `clang_copts` are) but also
             to all dependers of this target. Subject to "Make variable"
             substitution and Bourne shell tokenization.
+        clang_only_deps: A list of targets that are dependencies of only the
+            clang library.
         clang_srcs: The list of C, C++, Objective-C, or Objective-C++ sources
             for the clang library.
         data: The list of files needed by this target at runtime.
@@ -373,7 +376,7 @@ a mixed language Swift library, use a clang only library rule like \
         testonly = testonly,
         textual_hdrs = textual_hdrs,
         weak_sdk_frameworks = weak_sdk_frameworks,
-        deps = deps,
+        deps = deps + clang_only_deps,
         **kwargs
     )
 


### PR DESCRIPTION
At Square, we're using a headermap for the Swift generated header, so that the objective-C half of a module is able to import the swift generated header using `#import <Module/Module-Swift.h>`.

This can't be placed in `deps`, as doing so creates a dependency cycle.

Here is an example of what the user case looks like: https://github.com/bazelbuild/rules_swift/compare/master...jschear:rules_swift:js/demo_swift_header_imports_in_clang_half

```
mixed_language_library(
    name = "MixedAnswer",
    hdrs = ["MixedAnswer.h"],
    clang_copts = [
        "-I$(execpath :swift_headermap)",
        "-I.",
    ],
    clang_only_deps = [":swift_headermap"],
    clang_srcs = [
        "MixedAnswer.m",
        "MixedAnswerPrivate.m",
        "MixedAnswerPrivate.h",
    ],
    enable_modules = True,
    module_name = "MixedAnswer",
    swift_srcs = [
        "MixedAnswer.swift",
    ],
    target_compatible_with = ["@platforms//os:macos"],
)
```